### PR TITLE
chore: fix typo in docker volume mount

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -35,7 +35,7 @@ To mount a local `config.toml` file, add the following section to `docker-compos
     <<: *app-defaults
     depends_on:
       - db
-    volume:
+    volumes:
     - ./path/on/your/host/config.toml/:/listmonk/config.toml
 ```
 


### PR DESCRIPTION
Fixes a typo in `docker-compose.yml` as spotted in https://github.com/knadh/listmonk/issues/390#issuecomment-858663134