### PR TITLE
Remove non-functional PUT method

### DIFF
--- a/docs/docs/apis/subscribers.md
+++ b/docs/docs/apis/subscribers.md
@@ -10,7 +10,6 @@ Method   | Endpoint                                                             
 `POST`   | [/api/subscribers](#post-apisubscribers)                              | Creates a new subscriber.
 `PUT`    | [/api/subscribers/lists/:`id`](#put-apisubscriberslists_id)           | Modify a subscriber's list memberhips.
 `PUT`    | [/api/subscribers/lists](#put-apisubscriberslists)                    | Modify subscribers' list memberships.
-`PUT`    | /api/subscribers/:`id`                                                | Updates a subscriber by ID.
 `PUT`    | [/api/subscribers/:`id`/blocklist](#put-apisubscribersidblocklist)    | Blocklists a single subscriber.
 `PUT`    | /api/subscribers/blocklist                                            | Blocklists one or more subscribers.
 `PUT`    | [/api/subscribers/query/blocklist](#put-apisubscribersqueryblocklist) | Blocklists subscribers with an arbitrary SQL expression.
@@ -318,37 +317,6 @@ curl 'http://localhost:9000/api/subscribers' -H 'Content-Type: application/json'
   }
 }
 ```
-
-#### **`PUT`** /api/subscribers/lists/:id
-
-Modify a the subscriber with `:id`'s list memberships.
-
-##### Parameters
-
-Name              | Parameter type   | Data type | Required/Optional  | Description
-------------------|------------------|-----------|--------------------|-------------------------------------------------------
-`id`              | Query parameters | Number    | Required           | The id of the subscriber to be modified.
-`action`          | Request body     | String    | Required           | Wether to `add`, `remove`, or `unsubscribe` the users.
-`target_list_ids` | Request body     | Numbers   | Required           | The ids of the lists to be modified.
-`status`          | Request body     | String    | Required for `add` | `confirmed`, `unconfirmed`, or `unsubscribed` status.
-
-##### Example Request
-
-To subscribe users 1 to lists 4, 5, and 6:
-
-```shell
-curl -u "username:username" -X PUT 'http://localhost:9000/api/subscribers/lists/1' \
---data-raw '{"action": "add", "target_list_ids": [4, 5, 6], "status": "confirmed"}'
-```
-
-##### Example Response
-
-``` json
-{
-    "data": true
-} 
-```
-
 
 #### **`PUT`** /api/subscribers/lists
 


### PR DESCRIPTION
Re discussion on [listmonk issue #1012](https://github.com/knadh/listmonk/issues/1012):

The endpoint `/api/subscribers/lists/:id` doesn't seem to be functionally different from the endpoint for [modifying multiple users](https://listmonk.app/docs/apis/subscribers/#put-apisubscriberslists). It returns `{"message":"No IDs given."}`, even though the `id` is given in the url. It works if `"ids":[1]` (for example) is included in the payload, which in that case simply makes it identical to the method for multiple users.