### PR TITLE
🐛 — Fix curl params

### DIFF
--- a/docs/docs/apis/subscribers.md
+++ b/docs/docs/apis/subscribers.md
@@ -221,9 +221,9 @@ Gets subscribers with an SQL expression.
 ##### Example Request
 ```shell
 curl -X GET 'http://localhost:9000/api/subscribers' \
-    -d 'page=1' \
-    -d 'per_page=100' \
-    -d "query=subscribers.name LIKE 'Test%' AND subscribers.attribs->>'city' = 'Bengaluru'"
+    --url-query 'page=1' \
+    --url-query 'per_page=100' \
+    --url-query "query=subscribers.name LIKE 'Test%' AND subscribers.attribs->>'city' = 'Bengaluru'"
 ```
 
 To skip pagination and retrieve all records, pass `per_page=all`.


### PR DESCRIPTION
In https://listmonk.app/docs/apis/subscribers/, you do a GET request with curl but the parameters need to be added with `--url-query`, not `-d`, which is for POST requests.